### PR TITLE
PHP 7.3 and Li3 v1.2 support changes

### DIFF
--- a/extensions/adapter/security/access/AuthRbac.php
+++ b/extensions/adapter/security/access/AuthRbac.php
@@ -6,7 +6,7 @@ use lithium\security\Auth;
 use lithium\util\Inflector;
 use lithium\core\ConfigException;
 
-class AuthRbac extends \lithium\core\Object {
+class AuthRbac extends \lithium\core\ObjectDeprecated {
 
 	/**
 	 * @var array $_autoConfig


### PR DESCRIPTION
This changeset implements Li3 v1.2 fixed for `Object` word reservation in php 7.3